### PR TITLE
RequestHandler 보완

### DIFF
--- a/filenames.mk
+++ b/filenames.mk
@@ -72,6 +72,7 @@ FILENAMES			= \
 					$(DIR_HTTP)Server/RequestHandler/RequestGetHandler \
 					$(DIR_HTTP)Server/RequestHandler/RequestHeadHandler \
 					$(DIR_HTTP)Server/RequestHandler/RequestPostHandler \
+					$(DIR_HTTP)Server/RequestHandler/RequestPutHandler \
 					$(DIR_HTTP)Server/RequestHandler/RequestDeleteHandler \
 					$(DIR_HTTP)Server/Location \
 					$(DIR_HTTP)Server/LocationParseDirective \

--- a/filenames.mk
+++ b/filenames.mk
@@ -45,6 +45,7 @@ TESTDRIVERDEPS		= $(addprefix $(DIR_TESTOBJS), $(addsuffix .d, $(TESTDRIVERNAMES
 FILENAMES			= \
 					utils/string \
 					utils/file \
+					utils/hash \
 					Header/Header \
 					$(DIR_ASYNC_IO)IOProcessor \
 					$(DIR_ASYNC_IO)IOException \

--- a/includes/HTTP/RequestHandler.hpp
+++ b/includes/HTTP/RequestHandler.hpp
@@ -19,8 +19,8 @@ class Server::RequestHandler
 	Response _response;
 	int _status;
 	std::string _resource_path;
+	CGI::RequestHandler *_cgi_handler;
 	async::Logger &_logger;
-	void *_cgi_handler;
 
 	void registerErrorResponse(const int code, const std::exception &e);
 

--- a/includes/HTTP/RequestHandler.hpp
+++ b/includes/HTTP/RequestHandler.hpp
@@ -1,12 +1,12 @@
 #ifndef HTTP_REQUESTHANDLER_HPP
 #define HTTP_REQUESTHANDLER_HPP
 
+#include "CGI/RequestHandler.hpp"
 #include "HTTP/Request.hpp"
 #include "HTTP/Response.hpp"
 #include "HTTP/Server.hpp"
 #include "async/FileIOProcessor.hpp"
 #include "async/status.hpp"
-#include "CGI/RequestHandler.hpp"
 
 namespace HTTP
 {
@@ -35,10 +35,11 @@ class Server::RequestHandler
 				   const Server::Location &location);
 	virtual ~RequestHandler();
 
-	virtual int task(void) = 0;
+	int task(void);
 	Response retrieve(void);
 	void setCGIRequestValues(CGI::Request &cgi_request);
 	void handleCGI(void);
+	virtual void handleRequest(void) = 0;
 	void CGIResponseToHTTPResponse(const CGI::Response &cgi_response);
 
 	bool isDirectory(void) const;
@@ -55,7 +56,7 @@ class Server::RequestGetHandler : public Server::RequestHandler
 					  const Server::Location &location);
 	virtual ~RequestGetHandler();
 
-	virtual int task(void);
+	virtual void handleRequest(void);
 };
 
 class Server::RequestHeadHandler : public Server::RequestHandler
@@ -68,7 +69,7 @@ class Server::RequestHeadHandler : public Server::RequestHandler
 					   const Server::Location &location);
 	virtual ~RequestHeadHandler();
 
-	virtual int task(void);
+	virtual void handleRequest(void);
 };
 
 class Server::RequestPostHandler : public Server::RequestHandler
@@ -81,7 +82,7 @@ class Server::RequestPostHandler : public Server::RequestHandler
 					   const Server::Location &location);
 	virtual ~RequestPostHandler();
 
-	virtual int task(void);
+	virtual void handleRequest(void);
 };
 
 class Server::RequestDeleteHandler : public Server::RequestHandler
@@ -91,7 +92,7 @@ class Server::RequestDeleteHandler : public Server::RequestHandler
 						 const Server::Location &location);
 	virtual ~RequestDeleteHandler();
 
-	virtual int task(void);
+	virtual void handleRequest(void);
 };
 } // namespace HTTP
 

--- a/includes/HTTP/RequestHandler.hpp
+++ b/includes/HTTP/RequestHandler.hpp
@@ -85,6 +85,19 @@ class Server::RequestPostHandler : public Server::RequestHandler
 	virtual void handleRequest(void);
 };
 
+class Server::RequestPutHandler : public Server::RequestHandler
+{
+  private:
+	async::FileWriter *_writer;
+
+  public:
+	RequestPutHandler(Server *server, const Request &request,
+					  const Server::Location &location);
+	virtual ~RequestPutHandler();
+
+	virtual void handleRequest(void);
+};
+
 class Server::RequestDeleteHandler : public Server::RequestHandler
 {
   public:

--- a/includes/HTTP/Server.hpp
+++ b/includes/HTTP/Server.hpp
@@ -76,8 +76,6 @@ class Server
 	unsigned int getTimeout(void) const;
 	bool cgiEnabled(void) const;
 	const Location &getLocation(const std::string &location) const;
-	std::string getResourcePath(const Request &req,
-								const Location &location) const;
 	bool isCGIextension(const std::string &path) const;
 };
 } // namespace HTTP

--- a/includes/HTTP/Server.hpp
+++ b/includes/HTTP/Server.hpp
@@ -21,6 +21,7 @@ class Server
 	class RequestGetHandler;
 	class RequestHeadHandler;
 	class RequestPostHandler;
+	class RequestPutHandler;
 	class RequestDeleteHandler;
 
   private:

--- a/includes/HTTP/Server.hpp
+++ b/includes/HTTP/Server.hpp
@@ -76,7 +76,8 @@ class Server
 	unsigned int getTimeout(void) const;
 	bool cgiEnabled(void) const;
 	const Location &getLocation(const std::string &location) const;
-	std::string getResourcePath(const Request &req) const;
+	std::string getResourcePath(const Request &req,
+								const Location &location) const;
 	bool isCGIextension(const std::string &path) const;
 };
 } // namespace HTTP

--- a/includes/HTTP/ServerLocation.hpp
+++ b/includes/HTTP/ServerLocation.hpp
@@ -39,6 +39,7 @@ class Server::Location
 	const std::string &getPath(void) const;
 	const std::string &getAlias(void) const;
 	const std::string &getNthIndex(size_t nth) const;
+	const std::string &getUploadPath(void) const;
 	bool isAllowedMethod(int method) const;
 	bool hasIndex() const;
 	bool hasAutoIndex(void) const;

--- a/includes/HTTP/ServerLocation.hpp
+++ b/includes/HTTP/ServerLocation.hpp
@@ -40,6 +40,7 @@ class Server::Location
 	const std::string &getAlias(void) const;
 	const std::string &getNthIndex(size_t nth) const;
 	const std::string &getUploadPath(void) const;
+	std::string generateResourcePath(const Request &req) const;
 	bool isAllowedMethod(int method) const;
 	bool hasIndex() const;
 	bool hasAutoIndex(void) const;

--- a/includes/utils/hash.hpp
+++ b/includes/utils/hash.hpp
@@ -1,0 +1,10 @@
+#ifndef UTILS_HASH_HPP
+#define UTILS_HASH_HPP
+
+#include <string>
+
+extern size_t HASH_LEN;
+
+std::string generateHash(const std::string &input);
+
+#endif

--- a/srcs/HTTP/Server/Location.cpp
+++ b/srcs/HTTP/Server/Location.cpp
@@ -1,6 +1,7 @@
 #include "../const_values.hpp"
 #include "ConfigDirective.hpp"
 #include "HTTP/Server.hpp"
+#include "utils/hash.hpp"
 #include "utils/string.hpp"
 
 using namespace HTTP;
@@ -83,21 +84,33 @@ const std::string &Server::Location::getUploadPath(void) const
 std::string Server::Location::generateResourcePath(const Request &req) const
 {
 	std::string uri_path = req.getURIPath();
+	const int method = req.getMethod();
 
 	_logger << async::verbose << __func__ << ": URI path before replace \""
-			<< uri_path;
-	if ((req.getMethod() == METHOD_POST || req.getMethod() == METHOD_PUT)
-		&& _upload_allowed)
+			<< uri_path << "\"";
+	if (_upload_allowed && (method == METHOD_POST || method == METHOD_PUT))
 	{
-		uri_path.replace(0, _path.length(), _upload_store_path);
-		_logger << "\" after \"" << uri_path << "\"";
 		_logger << async::verbose << __func__
-				<< ": above path is for uploading";
+				<< ": generate resource path for upload";
+		switch (method)
+		{
+		case METHOD_POST: // upload_path/해시결과(URI에 현재 시각을 붙임)
+			uri_path = _upload_store_path;
+			if (uri_path.back() != '/')
+				uri_path += "/";
+			uri_path += generateHash(toStr(clock()) + req.getURIPath());
+			break;
+		case METHOD_PUT: // URI에서 path에 해당하는 부분 upload_path로 대체
+			uri_path.replace(0, _path.length(), _upload_store_path);
+			break;
+		}
+		_logger << async::verbose << __func__ << ": after \"" << uri_path
+				<< "\"";
 		return (uri_path);
 	}
 
 	uri_path.replace(0, _path.length(), _alias);
-	_logger << "\" after \"" << uri_path << "\"";
+	_logger << async::verbose << __func__ << ": after \"" << uri_path << "\"";
 	if (req.getURIPath().back() == '/' && _has_index)
 	{
 		uri_path += _index[0];

--- a/srcs/HTTP/Server/Location.cpp
+++ b/srcs/HTTP/Server/Location.cpp
@@ -80,6 +80,34 @@ const std::string &Server::Location::getUploadPath(void) const
 	return (_upload_store_path);
 }
 
+std::string Server::Location::generateResourcePath(const Request &req) const
+{
+	std::string uri_path = req.getURIPath();
+
+	_logger << async::verbose << __func__ << ": URI path before replace \""
+			<< uri_path;
+	if ((req.getMethod() == METHOD_POST || req.getMethod() == METHOD_PUT)
+		&& _upload_allowed)
+	{
+		uri_path.replace(0, _path.length(), _upload_store_path);
+		_logger << "\" after \"" << uri_path << "\"";
+		_logger << async::verbose << __func__
+				<< ": above path is for uploading";
+		return (uri_path);
+	}
+
+	uri_path.replace(0, _path.length(), _alias);
+	_logger << "\" after \"" << uri_path << "\"";
+	if (req.getURIPath().back() == '/' && _has_index)
+	{
+		uri_path += _index[0];
+		_logger << async::verbose << __func__
+				<< ": add index to URI path, result: \"" << uri_path << "\"";
+	}
+
+	return (uri_path);
+}
+
 bool Server::Location::isAllowedMethod(int method) const
 {
 	const std::set<int>::const_iterator iter = _allowed_methods.find(method);

--- a/srcs/HTTP/Server/Location.cpp
+++ b/srcs/HTTP/Server/Location.cpp
@@ -75,6 +75,11 @@ const std::string &Server::Location::getNthIndex(size_t nth) const
 	return (_index[nth]);
 }
 
+const std::string &Server::Location::getUploadPath(void) const
+{
+	return (_upload_store_path);
+}
+
 bool Server::Location::isAllowedMethod(int method) const
 {
 	const std::set<int>::const_iterator iter = _allowed_methods.find(method);

--- a/srcs/HTTP/Server/RequestHandler/RequestDeleteHandler.cpp
+++ b/srcs/HTTP/Server/RequestHandler/RequestDeleteHandler.cpp
@@ -8,28 +8,18 @@ Server::RequestDeleteHandler::RequestDeleteHandler(
 	Server *server, const Request &request, const Server::Location &location)
 	: RequestHandler(server, request, location)
 {
-	if (server->cgiEnabled() && server->isCGIextension(_resource_path))
-	{
-		// TODO: CGI 핸들러 완성시 주석 해제
-		// _cgi_handler = new CGIHandler(args);
-		return;
-	}
 }
 
 Server::RequestDeleteHandler::~RequestDeleteHandler()
 {
 }
 
-int Server::RequestDeleteHandler::task(void)
+void Server::RequestDeleteHandler::handleRequest(void)
 {
 	if (_status == Server::RequestHandler::RESPONSE_STATUS_OK)
-		return (_status);
+		return;
 
-	if (_cgi_handler)
-	{
-		handleCGI();
-	}
-	else if (unlink(_resource_path.c_str()) == -1)
+	if (unlink(_resource_path.c_str()) == -1)
 	{
 		switch (errno)
 		{
@@ -49,5 +39,4 @@ int Server::RequestDeleteHandler::task(void)
 		_response.setStatus(200);
 		_status = Server::RequestHandler::RESPONSE_STATUS_OK;
 	}
-	return (_status);
 }

--- a/srcs/HTTP/Server/RequestHandler/RequestHandler.cpp
+++ b/srcs/HTTP/Server/RequestHandler/RequestHandler.cpp
@@ -8,7 +8,7 @@ Server::RequestHandler::RequestHandler(Server *server, const Request &request,
 									   const Server::Location &location)
 	: _request(request), _location(location), _server(server),
 	  _status(RESPONSE_STATUS_AGAIN),
-	  _resource_path(server->getResourcePath(request, location)),
+	  _resource_path(location.generateResourcePath(request)),
 	  _cgi_handler(NULL), _logger(async::Logger::getLogger("RequestHandler"))
 {
 	if (_request.hasHeaderValue("Connection", "close"))

--- a/srcs/HTTP/Server/RequestHandler/RequestHandler.cpp
+++ b/srcs/HTTP/Server/RequestHandler/RequestHandler.cpp
@@ -15,10 +15,28 @@ Server::RequestHandler::RequestHandler(Server *server, const Request &request,
 		_response.setConnection(false);
 	else
 		_response.setConnection(true);
+	if (server->cgiEnabled() && server->isCGIextension(_resource_path))
+	{
+		// TODO: CGI 핸들러 완성시 주석 해제
+		// _cgi_handler = new CGIHandler(args);
+		return;
+	}
 }
 
 Server::RequestHandler::~RequestHandler()
 {
+	// TODO: CGI 핸들러 완성시 주석 해제
+	// if (_cgi_handler)
+	// 	delete _cgi_handler;
+}
+
+int Server::RequestHandler::task(void)
+{
+	if (_cgi_handler)
+		handleCGI();
+	else
+		handleRequest();
+	return (_status);
 }
 
 void Server::RequestHandler::registerErrorResponse(const int code,

--- a/srcs/HTTP/Server/RequestHandler/RequestHandler.cpp
+++ b/srcs/HTTP/Server/RequestHandler/RequestHandler.cpp
@@ -8,8 +8,8 @@ Server::RequestHandler::RequestHandler(Server *server, const Request &request,
 									   const Server::Location &location)
 	: _request(request), _location(location), _server(server),
 	  _status(RESPONSE_STATUS_AGAIN),
-	  _resource_path(server->getResourcePath(request)),
-	  _logger(async::Logger::getLogger("RequestHandler")), _cgi_handler(NULL)
+	  _resource_path(server->getResourcePath(request)), _cgi_handler(NULL),
+	  _logger(async::Logger::getLogger("RequestHandler"))
 {
 	if (_request.hasHeaderValue("Connection", "close"))
 		_response.setConnection(false);

--- a/srcs/HTTP/Server/RequestHandler/RequestHandler.cpp
+++ b/srcs/HTTP/Server/RequestHandler/RequestHandler.cpp
@@ -8,8 +8,8 @@ Server::RequestHandler::RequestHandler(Server *server, const Request &request,
 									   const Server::Location &location)
 	: _request(request), _location(location), _server(server),
 	  _status(RESPONSE_STATUS_AGAIN),
-	  _resource_path(server->getResourcePath(request)), _cgi_handler(NULL),
-	  _logger(async::Logger::getLogger("RequestHandler"))
+	  _resource_path(server->getResourcePath(request, location)),
+	  _cgi_handler(NULL), _logger(async::Logger::getLogger("RequestHandler"))
 {
 	if (_request.hasHeaderValue("Connection", "close"))
 		_response.setConnection(false);

--- a/srcs/HTTP/Server/RequestHandler/RequestHeadHandler.cpp
+++ b/srcs/HTTP/Server/RequestHandler/RequestHeadHandler.cpp
@@ -7,70 +7,64 @@ Server::RequestHeadHandler::RequestHeadHandler(Server *server,
 											   const Server::Location &location)
 	: RequestHandler(server, request, location), _reader(NULL)
 {
-	if (server->cgiEnabled() && server->isCGIextension(_resource_path))
-	{
-		// TODO: CGI 핸들러 완성시 주석 해제
-		// _cgi_handler = new CGIHandler(args);
+	if (_cgi_handler)
 		return;
-	}
 	_reader = new async::FileReader(_server->_timeout_ms, _resource_path);
 }
 
 Server::RequestHeadHandler::~RequestHeadHandler()
 {
-	// TODO: CGI 핸들러 완성시 주석 해제
-	// if (_cgi_handler)
-	// 	delete _cgi_handler;
 	if (_reader)
 		delete _reader;
 }
 
-int Server::RequestHeadHandler::task(void)
+void Server::RequestHeadHandler::handleRequest(void)
 {
 	if (_status == Server::RequestHandler::RESPONSE_STATUS_OK)
-		return (_status);
+		return;
 
-	if (_cgi_handler)
+	if (isInvalidDirectoryFormat())
 	{
-		handleCGI();
-	}
-	else if (_reader)
-	{
-		try
-		{
-			int rc = _reader->task();
-			if (rc == async::status::OK)
-			{
-				const std::string &content = _reader->retrieve();
-				_response.setStatus(200);
-				_response.setContentLength(content.length());
-				_response.setContentType(_resource_path);
-				_status = Server::RequestHandler::RESPONSE_STATUS_OK;
-			}
-			else if (rc == async::status::AGAIN)
-			{
-				_status = Server::RequestHandler::RESPONSE_STATUS_AGAIN;
-			}
-			else
-			{
-				// TODO: 세분화된 예외 처리
-				_response = _server->generateErrorResponse(500);
-				_status = Server::RequestHandler::RESPONSE_STATUS_OK;
-			}
-		}
-		catch (const async::IOProcessor::FileIsDirectory &e)
-		{
-			registerErrorResponse(404, e); // Not Found
-		}
-		catch (const async::FileIOProcessor::FileOpeningError &e)
-		{
-			registerErrorResponse(404, e); // Not Found
-		}
-		catch (const std::exception &e)
-		{
-			registerErrorResponse(500, e); // Internal Server Error
-		}
+		_response = _server->generateErrorResponse(301); // Not Found;
+		_response.setValue("Location", _request.getURIPath() + "/");
+		_status = Server::RequestHandler::RESPONSE_STATUS_OK;
+		_logger << async::warning << "invalid directory format, redirect to \""
+				<< _request.getURIPath() + "\"";
+		return;
 	}
 
-	return (_status);
+	try
+	{
+		int rc = _reader->task();
+		if (rc == async::status::OK)
+		{
+			const std::string &content = _reader->retrieve();
+			_response.setStatus(200);
+			_response.setContentLength(content.length());
+			_response.setContentType(_resource_path);
+			_status = Server::RequestHandler::RESPONSE_STATUS_OK;
+		}
+		else if (rc == async::status::AGAIN)
+		{
+			_status = Server::RequestHandler::RESPONSE_STATUS_AGAIN;
+		}
+		else
+		{
+			// TODO: 세분화된 예외 처리
+			_response = _server->generateErrorResponse(500);
+			_status = Server::RequestHandler::RESPONSE_STATUS_OK;
+		}
+	}
+	catch (const async::IOProcessor::FileIsDirectory &e)
+	{
+		registerErrorResponse(404, e); // Not Found
+	}
+	catch (const async::FileIOProcessor::FileOpeningError &e)
+	{
+		registerErrorResponse(404, e); // Not Found
+	}
+	catch (const std::exception &e)
+	{
+		registerErrorResponse(500, e); // Internal Server Error
+	}
 }

--- a/srcs/HTTP/Server/RequestHandler/RequestPostHandler.cpp
+++ b/srcs/HTTP/Server/RequestHandler/RequestPostHandler.cpp
@@ -39,11 +39,10 @@ void Server::RequestPostHandler::handleRequest(void)
 		{
 			std::string body = "made the file\n"
 							   "click <A href=\""
-							   + _request.getURIPath()
-							   + "\">here</A> to view it.";
+							   + _resource_path + "\">here</A> to view it.";
 
 			_response.setStatus(201); // Created
-			_response.setLocation(_request.getURIPath());
+			_response.setLocation(_resource_path);
 			_response.setBody(body);
 			_response.setContentType("text/html");
 			_response.setContentLength(body.length());

--- a/srcs/HTTP/Server/RequestHandler/RequestPutHandler.cpp
+++ b/srcs/HTTP/Server/RequestHandler/RequestPutHandler.cpp
@@ -1,0 +1,71 @@
+#include "HTTP/RequestHandler.hpp"
+#include "async/FileIOProcessor.hpp"
+
+using namespace HTTP;
+
+Server::RequestPutHandler::RequestPutHandler(Server *server,
+											 const Request &request,
+											 const Server::Location &location)
+	: RequestHandler(server, request, location), _writer(NULL)
+{
+	if (_cgi_handler)
+		return;
+	if (location.uploadAllowed())
+	{
+		_writer = new async::FileWriter(_server->_timeout_ms, _resource_path,
+										request.getBody());
+		return;
+	}
+	_response = _server->generateErrorResponse(500);
+	_status = Server::RequestHandler::RESPONSE_STATUS_OK;
+	_logger << async::warning << "This location doesn't allow uploads or CGI";
+}
+
+Server::RequestPutHandler::~RequestPutHandler()
+{
+	if (_writer)
+		delete _writer;
+}
+
+void Server::RequestPutHandler::handleRequest(void)
+{
+	if (_status == Server::RequestHandler::RESPONSE_STATUS_OK)
+		return;
+
+	try
+	{
+		int rc = _writer->task();
+		if (rc == async::status::OK)
+		{
+			std::string body = "made the file\n"
+							   "click <A href=\""
+							   + _request.getURIPath()
+							   + "\">here</A> to view it.";
+
+			_response.setStatus(201); // Created
+			_response.setLocation(_request.getURIPath());
+			_response.setBody(body);
+			_response.setContentType("text/html");
+			_response.setContentLength(body.length());
+			_status = Server::RequestHandler::RESPONSE_STATUS_OK;
+		}
+		else if (rc == async::status::AGAIN)
+		{
+			_status = Server::RequestHandler::RESPONSE_STATUS_AGAIN;
+		}
+		else
+		{
+			// TODO: 세분화된 예외 처리
+			_response = _server->generateErrorResponse(500);
+			_status = Server::RequestHandler::RESPONSE_STATUS_OK;
+		}
+	}
+	catch (const async::FileIOProcessor::FileOpeningError &e)
+	{
+		registerErrorResponse(503, e); // Service Unavailable
+	}
+	catch (const std::exception &e)
+	{
+		registerErrorResponse(500, e); // Internal Server Error
+	}
+}

--- a/srcs/HTTP/Server/RequestHandler/RequestPutHandler.cpp
+++ b/srcs/HTTP/Server/RequestHandler/RequestPutHandler.cpp
@@ -39,11 +39,10 @@ void Server::RequestPutHandler::handleRequest(void)
 		{
 			std::string body = "made the file\n"
 							   "click <A href=\""
-							   + _request.getURIPath()
-							   + "\">here</A> to view it.";
+							   + _resource_path + "\">here</A> to view it.";
 
 			_response.setStatus(201); // Created
-			_response.setLocation(_request.getURIPath());
+			_response.setLocation(_resource_path);
 			_response.setBody(body);
 			_response.setContentType("text/html");
 			_response.setContentLength(body.length());

--- a/srcs/HTTP/Server/Server.cpp
+++ b/srcs/HTTP/Server/Server.cpp
@@ -74,10 +74,10 @@ const Server::Location &Server::getLocation(const std::string &path) const
 	return (result->second);
 }
 
-std::string Server::getResourcePath(const Request &req) const
+std::string Server::getResourcePath(const Request &req,
+									const Location &location) const
 {
 	std::string uri_path = req.getURIPath();
-	const Location &location = getLocation(uri_path);
 	const std::string &alias = location.getAlias();
 
 	_logger << async::verbose << __func__ << ": URI path before replace \""

--- a/srcs/HTTP/Server/Server.cpp
+++ b/srcs/HTTP/Server/Server.cpp
@@ -74,37 +74,6 @@ const Server::Location &Server::getLocation(const std::string &path) const
 	return (result->second);
 }
 
-std::string Server::getResourcePath(const Request &req,
-									const Location &location) const
-{
-	std::string uri_path = req.getURIPath();
-	const std::string &alias = location.getAlias();
-
-	_logger << async::verbose << __func__ << ": URI path before replace \""
-			<< uri_path;
-	if ((req.getMethod() == METHOD_POST || req.getMethod() == METHOD_PUT)
-		&& location.uploadAllowed())
-	{
-		uri_path.replace(0, location.getPath().length(),
-						 location.getUploadPath());
-		_logger << "\" after \"" << uri_path << "\"";
-		_logger << async::verbose << __func__
-				<< ": above path is for uploading";
-		return (uri_path);
-	}
-
-	uri_path.replace(0, location.getPath().length(), alias);
-	_logger << "\" after \"" << uri_path << "\"";
-	if (req.getURIPath().back() == '/' && location.hasIndex())
-	{
-		uri_path += location.getNthIndex(0);
-		_logger << async::verbose << __func__
-				<< ": add index to URI path, result: \"" << uri_path << "\"";
-	}
-
-	return (uri_path);
-}
-
 bool Server::isCGIextension(const std::string &path) const
 {
 	std::string ext = getExtension(path);

--- a/srcs/HTTP/Server/Server.cpp
+++ b/srcs/HTTP/Server/Server.cpp
@@ -82,6 +82,17 @@ std::string Server::getResourcePath(const Request &req,
 
 	_logger << async::verbose << __func__ << ": URI path before replace \""
 			<< uri_path;
+	if ((req.getMethod() == METHOD_POST || req.getMethod() == METHOD_PUT)
+		&& location.uploadAllowed())
+	{
+		uri_path.replace(0, location.getPath().length(),
+						 location.getUploadPath());
+		_logger << "\" after \"" << uri_path << "\"";
+		_logger << async::verbose << __func__
+				<< ": above path is for uploading";
+		return (uri_path);
+	}
+
 	uri_path.replace(0, location.getPath().length(), alias);
 	_logger << "\" after \"" << uri_path << "\"";
 	if (req.getURIPath().back() == '/' && location.hasIndex())

--- a/srcs/HTTP/Server/ServerInterfaces.cpp
+++ b/srcs/HTTP/Server/ServerInterfaces.cpp
@@ -93,6 +93,9 @@ void Server::registerRequest(int client_fd, const Request &request)
 		case METHOD_POST:
 			handler = new RequestPostHandler(this, request, location);
 			break;
+		case METHOD_PUT:
+			handler = new RequestPutHandler(this, request, location);
+			break;
 		case METHOD_DELETE:
 			handler = new RequestDeleteHandler(this, request, location);
 			break;

--- a/srcs/HTTP/const_values.cpp
+++ b/srcs/HTTP/const_values.cpp
@@ -15,8 +15,8 @@ const std::pair<std::string, int> _METHOD[]
 	   std::pair<std::string, int>("GET", METHOD_GET),
 	   std::pair<std::string, int>("HEAD", METHOD_HEAD),
 	   std::pair<std::string, int>("POST", METHOD_POST),
-	   std::pair<std::string, int>("DELETE", METHOD_DELETE),
-	   std::pair<std::string, int>("PUT", METHOD_POST)};
+	   std::pair<std::string, int>("PUT", METHOD_PUT),
+	   std::pair<std::string, int>("DELETE", METHOD_DELETE)};
 
 const BidiMap<std::string, int> HTTP::METHOD(_METHOD, sizeof(_METHOD)
 														  / sizeof(_METHOD[0]));

--- a/srcs/HTTP/const_values.hpp
+++ b/srcs/HTTP/const_values.hpp
@@ -11,6 +11,7 @@ enum e_http_method
 	METHOD_GET,
 	METHOD_HEAD,
 	METHOD_POST,
+	METHOD_PUT,
 	METHOD_DELETE,
 };
 

--- a/srcs/utils/hash.cpp
+++ b/srcs/utils/hash.cpp
@@ -1,0 +1,21 @@
+#include <string>
+
+const size_t HASH_LEN = 16;
+
+std::string generateHash(const std::string &input)
+{
+	const std::string digits = "0123456789abcdef";
+	std::string hash(HASH_LEN, '0');
+	unsigned long simpleHash = 0;
+
+	for (size_t i = 0; i < input.size(); ++i)
+		simpleHash = input[i] + (simpleHash << 5) - simpleHash;
+
+	for (size_t i = 0; i < HASH_LEN; ++i)
+	{
+		hash[i] = digits[simpleHash % digits.size()];
+		simpleHash /= digits.size();
+	}
+
+	return (hash);
+}


### PR DESCRIPTION
RequestHandler 기반 클래스를 수정해서 CGI Handler를 호출하는 로직을 기반 클래스에 포함

- 각 파생 클래스의 task()를 콘크리트 메소드 handleRequest로 변경
- task()를 기반 클래스의 콘크리트 메소드로 변경
- 기반 클래스의 task()에서 cgi_handler가 있는지 체크하고 handleCGI 혹은 handleRequest를 호출할지 결정

지금 PUT 요청은 POST로 갈음하여서 구현되었는데 RequestPutHandler를 구현하고 RequestPostHandler도 고쳐서

- PUT
  - CGI 확장자일 시 CGI에게 넘김
  - upload_path 지정시 리소스를 idempotent하게 업데이트(같은 URI로 여러번 PUT시 같은 파일이 업데이트만 됨)
  - 둘 다 아닐 시 그냥 OK만 함
- POST
  - CGI 확장자일 시 CGI에게 넘김
  - upload_path 지정시 리소스를 새로 생성 (같은 URI로 여러번 PUT시 다른 이름의 파일이 여러개 생성)
  - 둘 다 아닐 시 그냥 OK만 함